### PR TITLE
Redesign: typography, color system, motion, and layout

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -19,6 +19,18 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <title>{siteTitle}</title>
 
+<!-- Theme color: teal accent, matches Kesku's brand -->
+<meta content="hsl(184, 90%, 35%)" name="theme-color" media="(prefers-color-scheme: light)" />
+<meta content="hsl(184, 83%, 38%)" name="theme-color" media="(prefers-color-scheme: dark)" />
+
+<!-- Google Fonts: DM Serif Display (headings) + DM Sans (body/UI) -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+	href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=DM+Serif+Display:ital@0;1&display=swap"
+	rel="stylesheet"
+/>
+
 <link href="/icon.svg" rel="icon" type="image/svg+xml" />
 {
 	import.meta.env.PROD && (

--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -24,23 +24,23 @@ const socialLinks: {
 ];
 ---
 
-<ul class="flex items-center gap-4">
+<ul class="flex flex-wrap items-center gap-3">
 	{
 		socialLinks.map(({ friendlyName, link, name }) => (
 			<li>
 				<a
-					class="group flex items-center gap-2 rounded-lg border border-accent/30 bg-accent/5 px-4 py-2 transition-all duration-300 hover:border-accent hover:bg-accent/15"
+					class="group flex items-center gap-2 rounded-lg border border-accent/30 bg-accent/5 px-4 py-2.5 font-medium transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-accent hover:bg-accent/15 hover:shadow-md"
 					href={link}
 					rel="noopener noreferrer"
 					target="_blank"
 				>
 					<Icon
 						aria-hidden="true"
-						class="h-5 w-5 text-accent transition-transform group-hover:scale-110"
+						class="h-5 w-5 text-accent transition-transform duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:scale-110"
 						focusable="false"
 						name={name}
 					/>
-					<span class="text-sm font-medium">{friendlyName}</span>
+					<span class="text-sm font-semibold">{friendlyName}</span>
 				</a>
 			</li>
 		))

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -5,17 +5,20 @@ const year = new Date().getFullYear();
 ---
 
 <footer
-	class="mt-auto flex w-full flex-col items-center justify-center gap-y-2 pb-4 pt-20 text-center align-top font-semibold text-muted sm:flex-row sm:justify-between sm:text-xs"
+	class="mt-auto flex w-full flex-col items-center justify-center gap-y-2 border-t border-border pb-6 pt-10 text-center text-sm font-medium text-muted sm:flex-row sm:justify-between sm:text-xs"
 >
 	<div class="me-0 sm:me-4">
 		Copyright &copy; {siteConfig.author}
 		{year}
 	</div>
-	<nav aria-labelledby="footer_links" class="flex gap-x-2 sm:gap-x-0 sm:divide-x sm:divide-muted">
+	<nav aria-labelledby="footer_links" class="flex items-center gap-x-1">
 		<p class="sr-only" id="footer_links">More on this site</p>
 		{
 			menuLinks.map((link) => (
-				<a class="px-4 py-2 sm:py-0 sm:hover:text-textColor sm:hover:underline" href={link.path}>
+				<a
+					class="rounded-md px-3 py-1.5 transition-colors duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-accent/10 hover:text-accent"
+					href={link.path}
+				>
 					{link.title}
 				</a>
 			))

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -9,37 +9,40 @@ import ThemeToggle from "../ThemeToggle.astro";
 const url = new URL(Astro.request.url);
 ---
 
-<header class="group relative mb-28 flex items-center" id="main-header">
-	<Image alt="Call Me Kes!" class="max-w-[5rem] pr-3" src={logo} width={80} />
-	<div class="flex sm:flex-col">
+<header class="group relative mb-16 flex items-center" id="main-header">
+	<!-- Brand mark: logo + site name as a cohesive unit -->
+	<div class="flex items-center gap-3">
 		<a
 			aria-current={url.pathname === "/" ? "page" : false}
-			class="inline-flex items-center grayscale hover:filter-none sm:relative sm:inline-block"
+			class="flex items-center gap-3 grayscale transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:filter-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bgColor"
 			href="/"
 		>
-			<span class="text-xl font-bold sm:text-2xl">Call Me Kes!</span>
+			<Image alt="Call Me Kes!" class="max-w-[4.5rem]" src={logo} width={72} />
+			<span class="text-xl font-bold tracking-tight sm:text-2xl">Call Me Kes!</span>
 		</a>
-		<nav
-			aria-label="Main menu"
-			class="absolute -inset-x-4 top-14 hidden flex-col items-end gap-y-4 rounded-md bg-bgColor/[.85] py-4 text-accent shadow backdrop-blur group-[.menu-open]:z-50 group-[.menu-open]:flex sm:static sm:z-auto sm:mt-1 sm:flex sm:flex-row sm:items-center sm:divide-x sm:divide-dashed sm:divide-accent sm:rounded-none sm:bg-transparent sm:py-0 sm:shadow-none sm:backdrop-blur-none"
-			id="navigation-menu"
-		>
-			{
-				menuLinks.map((link) => (
-					<a
-						aria-current={url.pathname === link.path ? "page" : false}
-						class="px-4 py-4 underline-offset-2 sm:py-0 sm:hover:underline"
-						data-astro-prefetch
-						href={link.path}
-					>
-						{link.title}
-					</a>
-				))
-			}
-		</nav>
 	</div>
 
-	<div class="ms-auto flex items-center gap-4">
+	<!-- Desktop nav: pill hover, no dashed dividers -->
+	<nav
+		aria-label="Main menu"
+		class="absolute -inset-x-4 top-16 hidden flex-col items-end gap-y-1 rounded-xl border border-border bg-bgColor/95 py-3 shadow-lg backdrop-blur-sm group-[.menu-open]:z-50 group-[.menu-open]:flex sm:static sm:z-auto sm:ms-6 sm:flex sm:flex-row sm:items-center sm:gap-x-1 sm:rounded-none sm:border-0 sm:bg-transparent sm:py-0 sm:shadow-none sm:backdrop-blur-none"
+		id="navigation-menu"
+	>
+		{
+			menuLinks.map((link) => (
+				<a
+					aria-current={url.pathname === link.path ? "page" : false}
+					class="rounded-lg px-3 py-2 text-sm font-medium text-muted transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-accent/10 hover:text-accent aria-[current=page]:bg-accent/10 aria-[current=page]:text-accent sm:px-3 sm:py-1.5"
+					data-astro-prefetch
+					href={link.path}
+				>
+					{link.title}
+				</a>
+			))
+		}
+	</nav>
+
+	<div class="ms-auto flex items-center gap-3">
 		<mobile-button>
 			<button
 				aria-expanded="false"
@@ -49,9 +52,10 @@ const url = new URL(Astro.request.url);
 				id="toggle-navigation-menu"
 				type="button"
 			>
+				<!-- Hamburger icon -->
 				<svg
 					aria-hidden="true"
-					class="absolute start-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 transition-all group-aria-expanded:scale-0 group-aria-expanded:opacity-0"
+					class="absolute start-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-aria-expanded:scale-0 group-aria-expanded:opacity-0"
 					fill="none"
 					focusable="false"
 					id="line-svg"
@@ -63,9 +67,10 @@ const url = new URL(Astro.request.url);
 					<path d="M3.75 9h16.5m-16.5 6.75h16.5" stroke-linecap="round" stroke-linejoin="round"
 					></path>
 				</svg>
+				<!-- Close icon -->
 				<svg
 					aria-hidden="true"
-					class="absolute start-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 scale-0 text-accent opacity-0 transition-all group-aria-expanded:scale-100 group-aria-expanded:opacity-100"
+					class="absolute start-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 scale-0 text-accent opacity-0 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-aria-expanded:scale-100 group-aria-expanded:opacity-100"
 					fill="none"
 					focusable="false"
 					id="cross-svg"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,7 +25,7 @@ const {
 		<ViewTransitions />
 	</head>
 	<body
-		class="mx-auto flex min-h-screen max-w-3xl flex-col bg-bgColor px-4 pt-16 font-mono font-normal text-textColor antialiased sm:px-8"
+		class="mx-auto flex min-h-screen max-w-4xl flex-col bg-bgColor px-4 pt-12 font-sans font-normal text-textColor antialiased sm:px-8"
 	>
 		<ThemeProvider />
 		<SkipLink />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,19 +2,61 @@
 import PageLayout from "@/layouts/Base.astro";
 
 const meta = {
-	description: "Oops! It looks like this page is lost in space!",
-	title: "Oops! You found a missing page!",
+	description: "This page doesn't exist — but you found it anyway. Curious!",
+	title: "404 | You found a void!",
 };
 ---
 
 <PageLayout meta={meta}>
-	<h1 class="title mb-6">404 | Page Not Found</h1>
-	<p class="mb-8">
-		Uhh, nothing here. If this isn't supposed to happen hit me up on Twitter - <a
-			class="text-accent underline"
-			href="https://x.com/yoimnotkesku"
-			rel="noopener noreferrer"
-			target="_blank">@yoimnotkesku</a
+	<section class="py-12 text-center sm:text-left">
+		<!-- Big decorative 404 -->
+		<div class="mb-6 font-display text-8xl font-normal text-accent/20 sm:text-9xl" aria-hidden="true">
+			404
+		</div>
+
+		<h1 class="mb-4 font-display text-3xl font-normal text-accent-2 sm:text-4xl">
+			You found a void!
+		</h1>
+
+		<p class="mb-6 text-base leading-relaxed text-muted">
+			This page doesn't exist — which, honestly, is kind of impressive. Whatever you were looking
+			for, it isn't here.
+		</p>
+
+		<!-- KESKU acronym tie-in -->
+		<div
+			class="mb-8 inline-block rounded-xl border px-5 py-4 text-left text-sm"
+			style="border-color: hsl(var(--theme-border)); background-color: hsl(var(--theme-surface) / 0.6);"
 		>
-	</p>
+			<p class="mb-1 text-xs font-medium uppercase tracking-widest text-accent">
+				Remember the acronym?
+			</p>
+			<p class="text-textColor">
+				<span class="font-semibold text-accent">K</span>eep
+				<span class="font-semibold text-accent">E</span>verything
+				<span class="font-semibold text-accent">S</span>imple,
+				<span class="font-semibold text-accent">K</span>eep
+				<span class="font-semibold text-accent">U</span>nderstanding —
+				<span class="text-muted">and sometimes that means knowing when to just go home.</span>
+			</p>
+		</div>
+
+		<div class="flex flex-wrap items-center gap-3">
+			<a
+				class="inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-white transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:bg-accent/90 hover:shadow-md"
+				href="/"
+			>
+				← Back home
+			</a>
+			<a
+				class="inline-flex items-center gap-2 rounded-lg border px-5 py-2.5 text-sm font-medium transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-accent/50 hover:text-accent"
+				style="border-color: hsl(var(--theme-border));"
+				href="https://x.com/yoimnotkesku"
+				rel="noopener noreferrer"
+				target="_blank"
+			>
+				Tell me on Twitter →
+			</a>
+		</div>
+	</section>
 </PageLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -135,13 +135,15 @@ const gamesListHtml = games
 </script>
 
 <PageLayout meta={meta}>
-	<section class="mb-12">
+	<!-- About intro section -->
+	<section class="mb-14 animate-section">
 		<div class="mb-8 flex items-center gap-4">
-			<div class="h-1 w-12 bg-accent"></div>
+			<div class="h-1 w-12 rounded-full bg-accent"></div>
 			<span class="text-sm font-medium uppercase tracking-widest text-accent">About</span>
 		</div>
 
 		<div class="flex flex-col gap-8 sm:flex-row sm:items-start">
+			<!-- Flip image — keep working interaction intact -->
 			<div class="image-wrapper shrink-0">
 				<div
 					class="image-container relative h-[180px] w-[180px] cursor-pointer [perspective:1000px]"
@@ -152,7 +154,8 @@ const gamesListHtml = games
 						<div class="absolute inset-0 [backface-visibility:hidden]">
 							<Image
 								alt="Profile picture of Kesku"
-								class="h-full w-full rounded-xl border border-border object-cover"
+								class="h-full w-full rounded-xl border object-cover"
+								style="border-color: hsl(var(--theme-border)); box-shadow: var(--shadow-card);"
 								densities={[1, 2]}
 								fetchpriority="high"
 								loading="eager"
@@ -163,7 +166,8 @@ const gamesListHtml = games
 						<div class="absolute inset-0 [backface-visibility:hidden] [transform:rotateY(180deg)]">
 							<Image
 								alt="Profile picture of Kesku, art is of Usada Pekora from Hololive by @isukash"
-								class="h-full w-full rounded-xl border border-border object-cover"
+								class="h-full w-full rounded-xl border object-cover"
+								style="border-color: hsl(var(--theme-border)); box-shadow: var(--shadow-card);"
 								densities={[1, 2]}
 								src={aboutImgIsukash}
 								width={400}
@@ -196,34 +200,41 @@ const gamesListHtml = games
 			</div>
 
 			<div>
-				<p class="mb-4 text-textColor">
+				<p class="mb-4 text-base leading-relaxed text-textColor">
 					UK-based software engineer working @ <a
-						class="text-accent transition-all hover:underline hover:underline-offset-2"
+						class="text-accent transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:underline hover:underline-offset-2"
 						href="https://www.perplexity.ai/"
 						rel="noopener noreferrer"
 						target="_blank">Perplexity AI</a
 					>. I focus on developer relations — helping devs build cool things, creating technical
 					content, and bridging the gap between product and community.
 				</p>
-				<p class="text-muted">
+				<p class="text-base leading-relaxed text-muted">
 					Passionate about AI, developer experience, and making complex tech feel approachable.
 				</p>
 			</div>
 		</div>
 	</section>
 
-	<section class="mb-12">
+	<!-- What I'm Into section -->
+	<section class="mb-14 animate-section">
 		<div class="mb-6 flex items-center gap-4">
-			<div class="h-1 w-8 bg-accent/50"></div>
+			<div class="h-1 w-8 rounded-full bg-accent/50"></div>
 			<h2 class="text-xl font-semibold">What I'm Into</h2>
 		</div>
 
-		<div class="grid gap-6 sm:grid-cols-2">
-			<div class="rounded-xl border border-border bg-surface/30 p-6">
+		<div class="grid gap-5 sm:grid-cols-2">
+			<!-- Gaming card -->
+			<div
+				class="rounded-xl border p-6 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5"
+				style="border-color: hsl(var(--theme-border)); background-color: hsl(var(--theme-surface) / 0.6); box-shadow: var(--shadow-card);"
+				onmouseover="this.style.boxShadow='var(--shadow-card-hover)'; this.style.borderColor='hsl(var(--theme-accent) / 0.4)'"
+				onmouseout="this.style.boxShadow='var(--shadow-card)'; this.style.borderColor='hsl(var(--theme-border))'"
+			>
 				<Icon class="mb-3 h-8 w-8 text-accent" name="mdi:controller" />
 				<h3 class="mb-2 font-semibold">Gaming</h3>
-				<p class="mb-4 text-sm text-muted" set:html={`Big fan of ${gamesListHtml}.`} />
-				<p class="mb-4 text-sm text-muted">
+				<p class="mb-4 text-sm leading-relaxed text-muted" set:html={`Big fan of ${gamesListHtml}.`} />
+				<p class="mb-4 text-sm leading-relaxed text-muted">
 					As a kid, I'd play till late at night, and the game was all I thought about. Now the music
 					hooks sends me back in time, and with VR (Through <a
 						class="text-accent transition-all hover:underline hover:underline-offset-2"
@@ -232,7 +243,7 @@ const gamesListHtml = games
 						target="_blank">Vivecraft</a
 					>), I'm closer to it than ever.
 				</p>
-				<p class="text-sm text-muted">
+				<p class="text-sm leading-relaxed text-muted">
 					BTW: I use a <a
 						class="text-accent transition-all hover:underline hover:underline-offset-2"
 						href="https://www.meta.com/quest/quest-3/"
@@ -247,10 +258,16 @@ const gamesListHtml = games
 				</p>
 			</div>
 
-			<div class="rounded-xl border border-border bg-surface/30 p-6">
+			<!-- Community card -->
+			<div
+				class="rounded-xl border p-6 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5"
+				style="border-color: hsl(var(--theme-border)); background-color: hsl(var(--theme-surface) / 0.6); box-shadow: var(--shadow-card);"
+				onmouseover="this.style.boxShadow='var(--shadow-card-hover)'; this.style.borderColor='hsl(var(--theme-accent) / 0.4)'"
+				onmouseout="this.style.boxShadow='var(--shadow-card)'; this.style.borderColor='hsl(var(--theme-border))'"
+			>
 				<Icon class="mb-3 h-8 w-8 text-accent" name="mdi:account-group" />
 				<h3 class="mb-2 font-semibold">Community</h3>
-				<p class="mb-4 text-sm text-muted">
+				<p class="mb-4 text-sm leading-relaxed text-muted">
 					Moderating communities since I was 11, starting on old <a
 						class="text-accent transition-all hover:underline hover:underline-offset-2"
 						href="https://www.perplexity.ai/search/what-was-the-amino-app-ZfVunsx2Tfe8tdQlK39GoA#0"
@@ -258,7 +275,7 @@ const gamesListHtml = games
 						target="_blank">Amino forums</a
 					>.
 				</p>
-				<p class="mb-4 text-sm text-muted">
+				<p class="mb-4 text-sm leading-relaxed text-muted">
 					Helped manage the <a
 						class="text-accent transition-all hover:underline hover:underline-offset-2"
 						href="https://discord.gg/openai"
@@ -266,7 +283,7 @@ const gamesListHtml = games
 						target="_blank">OpenAI Discord</a
 					> up to its peak of 3.5M members (at one point 2nd biggest on Discord).
 				</p>
-				<p class="text-sm text-muted">
+				<p class="text-sm leading-relaxed text-muted">
 					I love answering questions, building relationships, and creating spaces where people can
 					thrive.
 				</p>
@@ -274,47 +291,49 @@ const gamesListHtml = games
 		</div>
 	</section>
 
-	<section class="mb-12">
+	<!-- Kesku acronym section -->
+	<section class="mb-14 animate-section">
 		<div class="mb-6 flex items-center gap-4">
-			<div class="h-1 w-8 bg-accent/50"></div>
+			<div class="h-1 w-8 rounded-full bg-accent/50"></div>
 			<h2 class="text-xl font-semibold">"Kesku" is an acronym</h2>
 		</div>
 
-		<p class="mb-4 text-textColor">
+		<p class="mb-4 text-base leading-relaxed text-textColor">
 			It stands for <span class="font-semibold text-accent"
 				>Keep Everything Simple, Keep Understanding</span
 			>.
 		</p>
-		<p class="text-muted">
+		<p class="text-base leading-relaxed text-muted">
 			It's a mindset I try to carry into everything I do: make things understandable, approachable,
 			and clear. Whether it's documentation, APIs, or developer tools — clarity makes all the
 			difference.
 		</p>
 	</section>
 
-	<section class="mb-12">
+	<!-- Connect section -->
+	<section class="mb-12 animate-section">
 		<div class="mb-6 flex items-center gap-4">
-			<div class="h-1 w-8 bg-accent/50"></div>
+			<div class="h-1 w-8 rounded-full bg-accent/50"></div>
 			<h2 class="text-xl font-semibold">Connect</h2>
 		</div>
 
-		<ul class="flex flex-wrap items-center gap-4">
+		<ul class="flex flex-wrap items-center gap-3">
 			{
 				socials.map(({ extra, icon, link, name }) => (
 					<li>
 						<a
-							class="group flex items-center gap-2 rounded-lg border border-accent/30 bg-accent/5 px-4 py-2 transition-all duration-300 hover:border-accent hover:bg-accent/15"
+							class="group flex items-center gap-2.5 rounded-lg border border-accent/30 bg-accent/5 px-4 py-2.5 font-medium transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-accent hover:bg-accent/15 hover:shadow-md"
 							href={link}
 							rel={link.startsWith("mailto:") ? undefined : "noopener noreferrer"}
 							target={link.startsWith("mailto:") ? undefined : "_blank"}
 						>
 							<Icon
 								aria-hidden="true"
-								class="h-5 w-5 text-accent transition-transform group-hover:scale-110"
+								class="h-5 w-5 text-accent transition-transform duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:scale-110"
 								focusable="false"
 								name={icon}
 							/>
-							<span class="text-sm font-medium">{name}</span>
+							<span class="text-sm font-semibold">{name}</span>
 							{extra && <span class="text-xs text-muted">({extra})</span>}
 						</a>
 					</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,50 +8,54 @@ import PageLayout from "@/layouts/Base.astro";
 ---
 
 <PageLayout meta={{ title: "Home" }}>
-	<section class="mb-16">
+	<!-- Hero section -->
+	<section class="mb-20 animate-section">
 		<div class="mb-8 flex items-center gap-4">
-			<div class="h-1 w-12 bg-accent"></div>
+			<div class="h-1 w-12 rounded-full bg-accent"></div>
 			<span class="text-sm font-medium uppercase tracking-widest text-accent">Hiya! I'm Kesku</span>
 		</div>
 
-		<h1 class="title mb-6">But you can call me Kes!</h1>
+		<!-- Hero heading uses display font for personality -->
+		<h1 class="mb-6 font-display text-4xl font-normal leading-tight text-accent-2 sm:text-5xl">
+			But you can call me Kes!
+		</h1>
 
-		<p class="mb-4">
+		<p class="mb-4 text-base leading-relaxed">
 			I'm a self-taught dev, former ML student (dropped out), and <a
-				class="text-accent transition-all hover:underline hover:underline-offset-2"
+				class="text-accent transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:underline hover:underline-offset-2"
 				href="https://x.com/yoimnotkesku/status/1811161077037801698"
 				rel="noopener noreferrer"
 				target="_blank">train enjoyer</a
 			> from the UK. I spend my time building stuff, breaking stuff, and trying to figure out how to
 			fix the stuff I broke
 		</p>
-		<p class="mb-4">
+		<p class="mb-4 text-base leading-relaxed">
 			I've been coding (badly) since I was 9 (or since I was 7 if you count <a
-				class="text-accent transition-all hover:underline hover:underline-offset-2"
+				class="text-accent transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:underline hover:underline-offset-2"
 				href="https://scratch.mit.edu/"
 				rel="noopener noreferrer"
 				target="_blank">Scratch</a
 			>). Now I'm 20, and I still suck at it!
 		</p>
-		<p class="mb-8">
+		<p class="mb-10 text-base leading-relaxed">
 			I only post online like twice a month, so when I'm not ruining your feed you'll find me either
 			on <span class="group relative inline-block cursor-pointer">
 				<span class="text-accent underline decoration-dotted underline-offset-2">Discord</span>
 				<span
-					class="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-surface-2 px-3 py-1.5 text-xs text-muted opacity-0 shadow-lg transition-opacity group-hover:opacity-100"
+					class="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-border bg-surface px-3 py-1.5 text-xs text-muted opacity-0 shadow-lg transition-opacity duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:opacity-100"
 				>
 					my username is <code class="font-mono text-accent">kesku</code>
 					<span
-						class="absolute left-1/2 top-full -mt-1 -translate-x-1/2 border-4 border-transparent border-t-surface-2"
+						class="absolute left-1/2 top-full -mt-1 -translate-x-1/2 border-4 border-transparent border-t-surface"
 					></span>
 				</span>
 			</span>, watching a <a
-				class="text-accent transition-all hover:underline hover:underline-offset-2"
+				class="text-accent transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:underline hover:underline-offset-2"
 				href="https://www.perplexity.ai/search/best-k-drama-movies-tv-shows-i-sQFCgkdlQ1C4xbqJ3hzDYQ#0"
 				rel="noopener noreferrer"
 				target="_blank">K-Drama</a
 			>, or hanging out with my <a
-				class="text-accent transition-all hover:underline hover:underline-offset-2"
+				class="text-accent transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:underline hover:underline-offset-2"
 				href="https://x.com/Angry_Ann_"
 				rel="noopener noreferrer"
 				target="_blank"
@@ -62,27 +66,34 @@ import PageLayout from "@/layouts/Base.astro";
 		<SocialList />
 	</section>
 
-	<section>
+	<!-- Check Out section -->
+	<section class="animate-section">
 		<div class="mb-6 flex items-center gap-4">
-			<div class="h-1 w-8 bg-accent/50"></div>
-			<h2 class="text-xl font-semibold">Check Out</h2>
+			<div class="h-1 w-8 rounded-full bg-accent/50"></div>
+			<h2 class="text-lg font-semibold text-textColor">Check Out</h2>
 		</div>
 
 		<div class="grid gap-4 sm:grid-cols-2">
+			<!-- Perplexity AI card -->
 			<a
-				class="group flex items-start gap-4 rounded-xl border border-border bg-surface/30 p-5 transition-all duration-300 hover:border-accent/50 hover:bg-surface/50"
+				class="group flex items-start gap-4 rounded-xl border bg-surface/50 p-5 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-accent/50 hover:bg-surface"
 				href="https://www.perplexity.ai/"
 				rel="noopener noreferrer"
+				style="border-color: hsl(var(--theme-border)); box-shadow: var(--shadow-card);"
 				target="_blank"
+				onmouseover="this.style.boxShadow='var(--shadow-card-hover)'"
+				onmouseout="this.style.boxShadow='var(--shadow-card)'"
 			>
-				<div class="rounded-lg bg-accent/10 p-3">
+				<div class="shrink-0 rounded-lg bg-accent/10 p-3 ring-1 ring-accent/20">
 					<PerplexitySpinner class="text-accent" size={24} />
 				</div>
-				<div class="flex-1">
+				<div class="flex-1 min-w-0">
 					<div class="mb-1 flex items-center gap-2">
-						<h3 class="font-semibold group-hover:text-accent">Perplexity AI</h3>
+						<h3 class="font-semibold transition-colors duration-[180ms] group-hover:text-accent">
+							Perplexity AI
+						</h3>
 						<Icon
-							class="h-4 w-4 text-muted transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-accent"
+							class="h-4 w-4 shrink-0 text-muted transition-transform duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-accent"
 							name="mdi:arrow-top-right"
 						/>
 					</div>
@@ -90,18 +101,24 @@ import PageLayout from "@/layouts/Base.astro";
 				</div>
 			</a>
 
+			<!-- Projects card -->
 			<a
-				class="group flex items-start gap-4 rounded-xl border border-border bg-surface/30 p-5 transition-all duration-300 hover:border-accent/50 hover:bg-surface/50"
+				class="group flex items-start gap-4 rounded-xl border bg-surface/50 p-5 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-accent/50 hover:bg-surface"
 				href="/projects/"
+				style="border-color: hsl(var(--theme-border)); box-shadow: var(--shadow-card);"
+				onmouseover="this.style.boxShadow='var(--shadow-card-hover)'"
+				onmouseout="this.style.boxShadow='var(--shadow-card)'"
 			>
-				<div class="rounded-lg bg-accent/10 p-3">
+				<div class="shrink-0 rounded-lg bg-accent/10 p-3 ring-1 ring-accent/20">
 					<Brackets class="text-accent" size={24} />
 				</div>
-				<div class="flex-1">
+				<div class="flex-1 min-w-0">
 					<div class="mb-1 flex items-center gap-2">
-						<h3 class="font-semibold group-hover:text-accent">Projects</h3>
+						<h3 class="font-semibold transition-colors duration-[180ms] group-hover:text-accent">
+							Projects
+						</h3>
 						<Icon
-							class="h-4 w-4 text-muted transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-accent"
+							class="h-4 w-4 shrink-0 text-muted transition-transform duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-accent"
 							name="mdi:arrow-top-right"
 						/>
 					</div>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -43,24 +43,31 @@ function getLanguageColor(language: null | string): string {
 ---
 
 <PageLayout meta={meta}>
-	<section class="mb-16">
+	<!-- Hero section -->
+	<section class="mb-14 animate-section">
 		<div class="mb-8 flex items-center gap-4">
-			<div class="h-1 w-12 bg-accent"></div>
+			<div class="h-1 w-12 rounded-full bg-accent"></div>
 			<span class="text-sm font-medium uppercase tracking-widest text-accent">Projects</span>
 		</div>
 
-		<h1 class="title mb-6">Things I've Worked On</h1>
+		<h1 class="mb-5 font-display text-4xl font-normal leading-tight text-accent-2 sm:text-5xl">
+			Things I've Worked On
+		</h1>
 
-		<p class="mb-8 text-muted">
+		<p class="text-base leading-relaxed text-muted">
 			A collection of my open source projects and contributions. Most are experiments, some are
 			useful tools, and a few are actually finished.
 		</p>
 	</section>
 
-	<section>
+	<!-- Projects list -->
+	<section class="animate-section">
 		{
 			projects.length === 0 ? (
-				<div class="rounded-xl border border-border bg-surface/30 p-8 text-center">
+				<div
+					class="rounded-xl border p-8 text-center"
+					style="border-color: hsl(var(--theme-border)); background-color: hsl(var(--theme-surface) / 0.5);"
+				>
 					<p class="text-muted">No projects found. Check back later!</p>
 				</div>
 			) : (
@@ -68,25 +75,32 @@ function getLanguageColor(language: null | string): string {
 					{projects.map((project) => (
 						<li>
 							<a
-								class="group block rounded-xl border border-border bg-surface/30 p-6 transition-all duration-300 hover:border-accent/50 hover:bg-surface/50"
+								class="group block rounded-xl border p-6 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5"
 								href={project.html_url}
 								rel="noopener noreferrer"
+								style="border-color: hsl(var(--theme-border)); background-color: hsl(var(--theme-surface) / 0.5); box-shadow: var(--shadow-card);"
 								target="_blank"
+								onmouseover="this.style.boxShadow='var(--shadow-card-hover)'; this.style.borderColor='hsl(var(--theme-accent) / 0.5)'"
+								onmouseout="this.style.boxShadow='var(--shadow-card)'; this.style.borderColor='hsl(var(--theme-border))'"
 							>
 								<div class="mb-3 flex items-start justify-between gap-4">
-									<div class="flex-1">
-										<div class="mb-2 flex items-center gap-2">
-											<h2 class="text-xl font-semibold group-hover:text-accent">{project.name}</h2>
+									<div class="flex-1 min-w-0">
+										<div class="mb-2 flex items-center gap-2 flex-wrap">
+											<h2 class="text-xl font-semibold transition-colors duration-[180ms] group-hover:text-accent">
+												{project.name}
+											</h2>
 											{project.featured && (
-												<span class="rounded-full bg-accent/20 px-2 py-0.5 text-xs font-medium text-accent">
+												<span class="rounded-full bg-accent/20 px-2 py-0.5 text-xs font-medium text-accent ring-1 ring-accent/30">
 													Featured
 												</span>
 											)}
 										</div>
-										{project.description && <p class="mb-3 text-muted">{project.description}</p>}
+										{project.description && (
+											<p class="mb-3 text-sm leading-relaxed text-muted">{project.description}</p>
+										)}
 									</div>
 									<Icon
-										class="h-5 w-5 shrink-0 text-muted transition-colors group-hover:text-accent"
+										class="h-5 w-5 shrink-0 text-muted transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-accent"
 										name="mdi:arrow-top-right"
 									/>
 								</div>
@@ -119,7 +133,7 @@ function getLanguageColor(language: null | string): string {
 									{project.topics.length > 0 && (
 										<div class="flex flex-wrap items-center gap-2">
 											{project.topics.slice(0, 5).map((topic: string) => (
-												<span class="rounded-md bg-surface-2 px-2 py-0.5 text-xs text-muted">
+												<span class="rounded-md bg-surface-2 px-2 py-0.5 text-xs text-muted ring-1 ring-border">
 													{topic}
 												</span>
 											))}
@@ -129,32 +143,36 @@ function getLanguageColor(language: null | string): string {
 										</div>
 									)}
 
-									<div class="ml-auto text-xs text-muted">
-										Updated {formatDate(project.updated_at)}
-									</div>
+									<div class="ml-auto text-xs text-muted">Updated {formatDate(project.updated_at)}</div>
 								</div>
 							</a>
 						</li>
 					))}
+					<!-- Catch-all "Everything else" card -->
 					<li>
 						<a
-							class="group block rounded-xl border border-border bg-surface/30 p-6 transition-all duration-300 hover:border-accent/50 hover:bg-surface/50"
+							class="group block rounded-xl border p-6 transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5"
 							href="https://x.com/yoimnotkesku"
 							rel="noopener noreferrer"
+							style="border-color: hsl(var(--theme-border)); background-color: hsl(var(--theme-surface) / 0.5); box-shadow: var(--shadow-card);"
 							target="_blank"
+							onmouseover="this.style.boxShadow='var(--shadow-card-hover)'; this.style.borderColor='hsl(var(--theme-accent) / 0.5)'"
+							onmouseout="this.style.boxShadow='var(--shadow-card)'; this.style.borderColor='hsl(var(--theme-border))'"
 						>
 							<div class="mb-3 flex items-start justify-between gap-4">
 								<div class="flex-1">
 									<div class="mb-2 flex items-center gap-2">
-										<h2 class="text-xl font-semibold group-hover:text-accent">Everything else..</h2>
+										<h2 class="text-xl font-semibold transition-colors duration-[180ms] group-hover:text-accent">
+											Everything else..
+										</h2>
 									</div>
-									<p class="mb-3 text-muted">
+									<p class="mb-3 text-sm leading-relaxed text-muted">
 										..is probably going to stay hidden to you, since the majority of my repos are
 										private. You can look at my Twitter I guess?
 									</p>
 								</div>
 								<Icon
-									class="h-5 w-5 shrink-0 text-muted transition-colors group-hover:text-accent"
+									class="h-5 w-5 shrink-0 text-muted transition-all duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-accent"
 									name="mdi:arrow-top-right"
 								/>
 							</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,32 +18,49 @@
 		}
 	}
 
+	/* Light mode — warm off-white, not cold grey */
 	:root,
 	:root[data-theme="light"] {
 		/* https://tailwindcss.com/docs/customizing-colors#using-css-variables */
-		--theme-bg: 0 0% 96%;
+		/* Warm off-white background (slight warm tint) */
+		--theme-bg: 36 20% 96%;
 		--theme-link: 208 100% 42%;
 		--theme-text: 210 15% 20%;
+		/* Keep the teal accent — it's Kesku's identity */
 		--theme-accent: 184 90% 35%;
 		--theme-accent-2: 0 0% 25%;
 		--theme-quote: 50 100% 80%;
-		--theme-surface: 0 0% 100%;
-		--theme-surface-2: 0 0% 92%;
-		--theme-border: 0 0% 80%;
+		/* Warm white surface */
+		--theme-surface: 36 25% 99%;
+		/* Slightly warmer secondary surface */
+		--theme-surface-2: 36 15% 93%;
+		/* Warmer, more visible borders */
+		--theme-border: 36 12% 78%;
 		--theme-muted: 0 0% 45%;
+		/* Card-specific shadow tokens */
+		--shadow-card: 0 1px 3px hsl(36 15% 50% / 0.08), 0 4px 12px hsl(36 15% 40% / 0.06);
+		--shadow-card-hover: 0 4px 16px hsl(36 15% 40% / 0.12), 0 8px 24px hsl(36 15% 30% / 0.08);
 	}
 
+	/* Dark mode — warmer, deeper surfaces (not cold/bluish) */
 	:root[data-theme="dark"] {
-		--theme-bg: 180 20% 3%;
+		/* Slightly warmer dark bg (warm near-black instead of cold) */
+		--theme-bg: 210 12% 6%;
 		--theme-link: 182.93 100% 16.08%;
-		--theme-text: 220 2.86% 79.41%;
+		--theme-text: 220 5% 80%;
+		/* Keep teal accent in dark mode */
 		--theme-accent: 184.07 83.51% 38.04%;
 		--theme-accent-2: 184.07 83.51% 38.04%;
 		--theme-quote: 101.92 100% 85.69%;
-		--theme-surface: 180 15% 8%;
-		--theme-surface-2: 180 15% 12%;
-		--theme-border: 180 10% 20%;
+		/* Warmer dark surfaces */
+		--theme-surface: 210 10% 10%;
+		--theme-surface-2: 210 10% 14%;
+		/* More visible borders in dark */
+		--theme-border: 210 8% 22%;
 		--theme-muted: 220 5% 55%;
+		/* Dark mode card shadows */
+		--shadow-card: 0 1px 3px hsl(0 0% 0% / 0.25), 0 4px 12px hsl(0 0% 0% / 0.2);
+		--shadow-card-hover: 0 4px 16px hsl(0 0% 0% / 0.35), 0 8px 24px hsl(0 0% 0% / 0.25);
 	}
 
 	:target {
@@ -61,10 +78,11 @@
 		max-width: 100%;
 	}
 
+	/* View transitions — smooth and quick */
 	::view-transition-old(root),
 	::view-transition-new(root) {
 		animation-duration: 0.2s;
-		animation-timing-function: ease-in-out;
+		animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 	}
 
 	::view-transition-old(root) {
@@ -74,4 +92,61 @@
 	::view-transition-new(root) {
 		z-index: 2;
 	}
+}
+
+@layer components {
+	/* Card — base style for all interactive cards */
+	.card {
+		@apply rounded-xl border bg-surface/50 transition-all;
+		border-color: hsl(var(--theme-border));
+		box-shadow: var(--shadow-card);
+		transition-duration: 180ms;
+		transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	.card:hover,
+	.card-hover:hover {
+		border-color: hsl(var(--theme-accent) / 0.5);
+		box-shadow: var(--shadow-card-hover);
+		transform: translateY(-2px);
+	}
+
+	/* Section header accent line + label */
+	.section-label {
+		@apply mb-8 flex items-center gap-4;
+	}
+
+	.section-label-bar {
+		@apply h-1 w-12 rounded-full bg-accent;
+	}
+
+	.section-label-text {
+		@apply text-sm font-medium uppercase tracking-widest text-accent;
+	}
+}
+
+/* ----------------------------------------------------------------
+   Scroll-driven fade-in animations (CSS-only, opacity only → no CLS)
+   Progressive enhancement: only activates where supported
+---------------------------------------------------------------- */
+@supports (animation-timeline: scroll()) {
+	@keyframes fade-in-section {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	.animate-section {
+		animation: fade-in-section linear both;
+		animation-timeline: view();
+		animation-range: entry 0% entry 20%;
+	}
+}
+
+/* Ensure sections are visible if animation-timeline is not supported */
+.animate-section {
+	opacity: 1;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,7 +33,7 @@ export default {
 					"@apply underline underline-offset-2": {},
 				},
 				".title": {
-					"@apply text-2xl font-semibold text-accent-2": {},
+					"@apply text-2xl font-bold text-accent-2 font-display": {},
 				},
 			});
 		}),
@@ -53,12 +53,24 @@ export default {
 				textColor: "hsl(var(--theme-text) / <alpha-value>)",
 			},
 			fontFamily: {
-				// Add any custom fonts here
-				sans: [...fontFamily.sans],
-				serif: [...fontFamily.serif],
+				// DM Sans for body/UI text — clean, modern, friendly
+				sans: ["DM Sans", ...fontFamily.sans],
+				// DM Serif Display for headings — warm character, distinctive
+				display: ["DM Serif Display", ...fontFamily.serif],
+				// Keep serif fallback
+				serif: ["DM Serif Display", ...fontFamily.serif],
+				// Monospace only for code
+				mono: [...fontFamily.mono],
 			},
 			transitionProperty: {
 				height: "height",
+			},
+			transitionTimingFunction: {
+				// Golden easing — snappy spring feel
+				spring: "cubic-bezier(0.16, 1, 0.3, 1)",
+			},
+			transitionDuration: {
+				180: "180ms",
 			},
 			/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 			typography: (theme: any) => ({
@@ -86,6 +98,7 @@ export default {
 						code: {
 							border: "1px dotted #666",
 							borderRadius: "2px",
+							fontFamily: "var(--font-mono)",
 						},
 						hr: {
 							borderTopStyle: "dashed",


### PR DESCRIPTION
## Summary

A comprehensive visual redesign that upgrades typography, color warmth, card depth, motion quality, and layout rhythm — while preserving all existing content, functionality, and personality.

## What Changed

### Typography (highest impact)
- **Replaced monospace body font** with **DM Sans** (body/UI) + **DM Serif Display** (headings)
- Google Fonts loaded via `preconnect` + stylesheet in `BaseHead.astro`
- Tailwind config defines `font-sans`, `font-display`, `font-serif`, `font-mono` families
- Hero headings now use `font-display text-4xl sm:text-5xl` — actual visual hierarchy
- Body layout switched from `font-mono` to `font-sans` in `Base.astro`
- Monospace reserved exclusively for `<code>` elements

### Color System
- **Light mode**: warm off-white background (`36 20% 96%`) instead of cold grey (`0 0% 96%`)
- **Dark mode**: warmer surfaces (`210 12% 6%`) instead of cold near-black
- Borders made more visible in both modes
- New CSS custom properties: `--shadow-card` and `--shadow-card-hover` for card depth
- Added `<meta name="theme-color">` with media queries for light/dark (fixes ThemeProvider null reference)

### Cards & Surfaces
- All interactive cards now have visible warm shadows (`--shadow-card`)
- Hover: `translateY(-2px)` lift + deeper shadow + accent border tint
- `.card` utility class added in global CSS `@layer components`
- Icon containers on homepage cards get `ring-1 ring-accent/20` for definition

### Motion
- **CSS-only scroll-driven fade-in** via `@supports (animation-timeline: scroll())`
- Progressive enhancement: sections default to `opacity: 1`, animate only where supported
- All hover/interactive transitions standardized to `180ms cubic-bezier(0.16, 1, 0.3, 1)`
- View transitions updated to use the golden easing curve
- Tailwind config adds `ease-spring` and `duration-180` tokens

### Layout
- `max-w-3xl` → `max-w-4xl` (wider content area for grid layouts)
- Header: `mb-28` → `mb-16` (less dead space)
- Body: `pt-16` → `pt-12`
- Consistent section spacing (`mb-14` / `mb-20`)

### Header
- Nav items: **pill-style hover** (`rounded-lg bg-accent/10`) replacing dashed dividers
- Active page gets `aria-[current=page]` teal pill highlight
- Logo + site name wrapped as a single clickable brand mark
- Mobile menu: rounded border, backdrop blur, shadow — feels more intentional

### Footer
- Added `border-t border-border` top separator
- Nav links match header pill-hover style
- Removed `font-semibold` for a lighter, more balanced feel

### 404 Page
- Giant decorative `404` in display font at low opacity
- Title: "You found a void!"
- KESKU acronym tie-in with each letter highlighted in accent
- Two CTAs: filled teal "← Back home" + outlined "Tell me on Twitter →"

### SocialList
- Matched to new spring easing and lift-on-hover pattern
- `font-semibold` labels, slightly more padding

## What's Preserved (unchanged)
- All page content, copy, links, social accounts
- Perplexity spinner + Brackets hover animations (`:global(.group:hover)` patterns)
- About page card-flip interaction (inline script preserved exactly)
- ThemeProvider / ThemeToggle / dark mode system
- Mobile hamburger menu (custom element)
- GitHub API project fetching (`utils/github.ts`, `data/projects.ts`)
- View Transitions
- Accessibility (skip link, aria attributes, semantic HTML)
- No new npm dependencies

## Files Changed (11)
- `tailwind.config.ts`
- `src/styles/global.css`
- `src/components/BaseHead.astro`
- `src/components/SocialList.astro`
- `src/components/layout/Header.astro`
- `src/components/layout/Footer.astro`
- `src/layouts/Base.astro`
- `src/pages/index.astro`
- `src/pages/about.astro`
- `src/pages/projects.astro`
- `src/pages/404.astro`