### PR TITLE
Added shared socialLinks config

### DIFF
--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -1,49 +1,31 @@
 ---
 import { Icon } from "astro-icon/components";
 
-const socialLinks: {
-	friendlyName: string;
-	link: string;
-	name: string;
-}[] = [
-	{
-		friendlyName: "GitHub",
-		link: "https://github.com/kesku",
-		name: "mdi:github",
-	},
-	{
-		friendlyName: "Twitter",
-		link: "https://x.com/yoimnotkesku",
-		name: "mdi:twitter",
-	},
-	{
-		friendlyName: "Discord",
-		link: "https://discordapp.com/users/539468067923820546",
-		name: "mdi:discord",
-	},
-];
+import { socialLinks } from "@/site-config";
 ---
 
 <ul class="flex items-center gap-4">
 	{
-		socialLinks.map(({ friendlyName, link, name }) => (
-			<li>
-				<a
-					class="group flex items-center gap-2 rounded-lg border border-accent/30 bg-accent/5 px-4 py-2 transition-all duration-300 hover:border-accent hover:bg-accent/15"
-					href={link}
-					rel="noopener noreferrer"
-					target="_blank"
-				>
-					<Icon
-						aria-hidden="true"
-						class="h-5 w-5 text-accent transition-transform group-hover:scale-110"
-						focusable="false"
-						is:inline
-						name={name}
-					/>
-					<span class="text-sm font-medium">{friendlyName}</span>
-				</a>
-			</li>
-		))
+		socialLinks
+			.filter(({ link }) => !link.startsWith("mailto:"))
+			.map(({ friendlyName, icon, link }) => (
+				<li>
+					<a
+						class="group flex items-center gap-2 rounded-lg border border-accent/30 bg-accent/5 px-4 py-2 transition-all duration-300 hover:border-accent hover:bg-accent/15"
+						href={link}
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						<Icon
+							aria-hidden="true"
+							class="h-5 w-5 text-accent transition-transform group-hover:scale-110"
+							focusable="false"
+							is:inline
+							name={icon}
+						/>
+						<span class="text-sm font-medium">{friendlyName}</span>
+					</a>
+				</li>
+			))
 	}
 </ul>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,6 +4,7 @@ import { Icon } from "astro-icon/components";
 import AboutProfileCard from "@/components/AboutProfileCard.astro";
 import ClawdPeek from "@/components/ClawdPeek.astro";
 import PageLayout from "@/layouts/Base.astro";
+import { socialLinks } from "@/site-config";
 
 const meta = {
 	description:
@@ -17,13 +18,6 @@ const games = [
 	{ link: "https://store.steampowered.com/app/1091500/", name: "Cyberpunk 2077" },
 	{ link: "https://store.steampowered.com/app/3240220/", name: "GTA Online" },
 	{ link: "https://www.minecraft.net/", name: "Minecraft" },
-];
-
-const socials = [
-	{ icon: "mdi:github", link: "https://github.com/kesku", name: "GitHub" },
-	{ icon: "mdi:twitter", link: "https://x.com/yoimnotkesku", name: "Twitter" },
-	{ icon: "mdi:discord", link: "https://discordapp.com/users/539468067923820546", name: "Discord" },
-	{ extra: "admin@kesku.me", icon: "mdi:email", link: "mailto:admin@kesku.me", name: "Email" },
 ];
 
 const gamesListHtml = games
@@ -165,7 +159,7 @@ const gamesListHtml = games
 
 		<ul class="flex flex-wrap items-center gap-4">
 			{
-				socials.map(({ extra, icon, link, name }) => (
+				socialLinks.map(({ extra, friendlyName, icon, link }) => (
 					<li>
 						<a
 							class="group flex items-center gap-2 rounded-lg border border-accent/30 bg-accent/5 px-4 py-2 transition-all duration-300 hover:border-accent hover:bg-accent/15"
@@ -180,7 +174,7 @@ const gamesListHtml = games
 								is:inline
 								name={icon}
 							/>
-							<span class="text-sm font-medium">{name}</span>
+							<span class="text-sm font-medium">{friendlyName}</span>
 							{extra && <span class="text-xs text-muted">({extra})</span>}
 						</a>
 					</li>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -22,3 +22,32 @@ export const menuLinks: { path: string; title: string }[] = [
 		title: "Projects",
 	},
 ];
+
+export const socialLinks: {
+	extra?: string;
+	friendlyName: string;
+	icon: string;
+	link: string;
+}[] = [
+	{
+		friendlyName: "GitHub",
+		icon: "mdi:github",
+		link: "https://github.com/kesku",
+	},
+	{
+		friendlyName: "Twitter",
+		icon: "mdi:twitter",
+		link: "https://x.com/yoimnotkesku",
+	},
+	{
+		friendlyName: "Discord",
+		icon: "mdi:discord",
+		link: "https://discordapp.com/users/539468067923820546",
+	},
+	{
+		extra: "admin@kesku.me",
+		friendlyName: "Email",
+		icon: "mdi:email",
+		link: "mailto:admin@kesku.me",
+	},
+];


### PR DESCRIPTION
## Summary
- add a shared socialLinks config in site config
- update the social list component to reuse the shared links
- update the about page connect section to reuse the shared links

## Verification
- bun run check
- bun run lint *(fails due to existing ESLint/Node heap OOM in this repo)*